### PR TITLE
fix(message-alerts): fix message alerts to disappear quicker

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -71,10 +71,7 @@ class App extends Component {
             path="/"
             render={() => <Index user={user} searchValue={searchValue} />}
           />
-          <Route
-            path="/private-policy"
-            render={() => <PrivatePolicy msgAlert={this.msgAlert} />}
-          />
+          <Route path="/private-policy" render={() => <PrivatePolicy />} />
           <AuthenticatedRoute
             user={user}
             path="/sign-out"

--- a/src/components/AutoDismissAlert/AutoDismissAlert.js
+++ b/src/components/AutoDismissAlert/AutoDismissAlert.js
@@ -15,7 +15,7 @@ class AutoDismissAlert extends React.Component {
   componentDidMount() {
     this.timer = setInterval(() => {
       this.setState({ show: false })
-    }, 5000)
+    }, 2000)
   }
 
   componentWillUnmount() {
@@ -33,7 +33,7 @@ class AutoDismissAlert extends React.Component {
         variant={variant}
         onClose={this.handleClose}
       >
-        <div className="container">
+        <div className="message-alert-container">
           <Alert.Heading>{heading}</Alert.Heading>
           <p className="alert-body">{message}</p>
         </div>

--- a/src/components/AutoDismissAlert/AutoDismissAlert.scss
+++ b/src/components/AutoDismissAlert/AutoDismissAlert.scss
@@ -1,6 +1,6 @@
 .alert {
   align-items: center;
-  animation: .5s ease-in-out 0s 1 light-bounce-in;
+  animation: 0.5s ease-in-out 0s 1 light-bounce-in;
   bottom: 1rem;
   display: flex;
   left: 0;
@@ -20,6 +20,14 @@
   &:focus {
     outline: none;
   }
+}
+
+.message-alert-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
 }
 
 @keyframes light-bounce-in {


### PR DESCRIPTION
#### Summary

- Work Type: Fix
- Fixes: 

#### What I did

- Changed the timer for message alerts to disappear after 2 seconds instead of 5
- Deleted a prop on private policy message alerts because it doesn't use prop on the app route and it doesn't need message alerts

#### Notes / Research / References

<!-- Insert reference links or tutorial articles -->

-
-

#### Screenshots

<!-- Provide screenshot below if applicable -->

#### Checklist

- [ ] Commits are descriptive
- [ ] Has Summary
